### PR TITLE
Postgre sql support for ef schema support

### DIFF
--- a/EfCoreInAction.Test.sln
+++ b/EfCoreInAction.Test.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSupport", "TestSupport\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Net472Test", "Net472Test\Net472Test.csproj", "{77C5DA91-75DB-48DD-A6C1-3B7483DB2E8B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCore31Test", "NetCore31Test\NetCore31Test.csproj", "{020DAA30-A361-42AB-91AD-766FB39CBDF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,26 @@ Global
 		{77C5DA91-75DB-48DD-A6C1-3B7483DB2E8B}.Release|x64.Build.0 = Release|Any CPU
 		{77C5DA91-75DB-48DD-A6C1-3B7483DB2E8B}.Release|x86.ActiveCfg = Release|Any CPU
 		{77C5DA91-75DB-48DD-A6C1-3B7483DB2E8B}.Release|x86.Build.0 = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|ARM.Build.0 = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|x64.Build.0 = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Debug|x86.Build.0 = Debug|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|ARM.ActiveCfg = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|ARM.Build.0 = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|ARM64.Build.0 = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|x64.ActiveCfg = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|x64.Build.0 = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|x86.ActiveCfg = Release|Any CPU
+		{020DAA30-A361-42AB-91AD-766FB39CBDF3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NetCore31Test/Fixtures/PostgreSqlDatabaseFixture.cs
+++ b/NetCore31Test/Fixtures/PostgreSqlDatabaseFixture.cs
@@ -40,7 +40,7 @@ namespace NetCore31Test.Fixtures
             DbContext = (T) Activator.CreateInstance(typeof(T), builder.Options);
 
             if (DbContext == null)
-                throw new InvalidOperationException("TODO");
+                throw new NullReferenceException($"{nameof(DbContext)} not initialized successfully, activator failed.");
 
             await DbContext.Database.EnsureDeletedAsync();
 

--- a/NetCore31Test/Fixtures/PostgreSqlDatabaseFixture.cs
+++ b/NetCore31Test/Fixtures/PostgreSqlDatabaseFixture.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Containers.Builders;
+using DotNet.Testcontainers.Containers.Configurations.Databases;
+using DotNet.Testcontainers.Containers.Modules.Databases;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace NetCore31Test.Fixtures
+{
+    public class PostgreSqlDatabaseFixture<T> : IAsyncLifetime where T : DbContext
+    {
+        public T DbContext;
+
+        private PostgreSqlTestcontainer PostgreSqlTestContainer { get; set; }
+
+        public async Task InitializeAsync()
+        {
+            var testContainersBuilder = new TestcontainersBuilder<PostgreSqlTestcontainer>()
+                .WithDatabase(new PostgreSqlTestcontainerConfiguration
+                {
+                    Database = "db",
+                    Username = "postgres",
+                    Password = "postgres",
+                });
+
+            // Use specific Docker endpoint from env variable, if it exists.
+            // Handy when running in special environments, as Bitbucket Pipelines.
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOCKER_HOST")))
+            {
+                testContainersBuilder = testContainersBuilder.WithDockerEndpoint(Environment.GetEnvironmentVariable("DOCKER_HOST"));
+            }
+
+            PostgreSqlTestContainer = testContainersBuilder.Build();
+            await PostgreSqlTestContainer.StartAsync();
+
+            // Init DB context.
+            var builder = new DbContextOptionsBuilder<T>();
+            builder.UseNpgsql(PostgreSqlTestContainer.ConnectionString);
+            DbContext = (T) Activator.CreateInstance(typeof(T), builder.Options);
+
+            if (DbContext == null)
+                throw new InvalidOperationException("TODO");
+
+            await DbContext.Database.EnsureDeletedAsync();
+
+            // Apply EF Core migrations.
+            await DbContext.Database.MigrateAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await DbContext.DisposeAsync();
+            await PostgreSqlTestContainer.DisposeAsync();
+        }
+    }
+}

--- a/NetCore31Test/NetCore31Test.csproj
+++ b/NetCore31Test/NetCore31Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DataLayer\DataLayer.csproj" />
+    <ProjectReference Include="..\TestSupport\TestSupport.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NetCore31Test/UnitTests/EfSchemaCompare/TestDesignTimeServiceProviderPostgreSql.cs
+++ b/NetCore31Test/UnitTests/EfSchemaCompare/TestDesignTimeServiceProviderPostgreSql.cs
@@ -1,0 +1,61 @@
+﻿using DataLayer.EfCode.BookApp;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using NetCore31Test.Fixtures;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Scaffolding.Internal;
+using TestSupport.DesignTimeServices;
+using Xunit;
+using Xunit.Extensions.AssertExtensions;
+
+namespace NetCore31Test.UnitTests.EfSchemaCompare
+{
+    public class TestDesignTimeServiceProviderPostgreSql : IClassFixture<PostgreSqlDatabaseFixture<BookContext>>
+    {
+        private readonly BookContext _bookContext;
+
+        public TestDesignTimeServiceProviderPostgreSql(PostgreSqlDatabaseFixture<BookContext> fixture)
+        {
+            _bookContext = fixture.DbContext;
+        }
+
+        [Fact]
+        public void GetDatabaseProviderPostgreSql()
+        {
+            // Act.
+            var dbProvider = _bookContext.GetService<IDatabaseProvider>();
+
+            // Assert.
+            dbProvider.ShouldNotBeNull();
+            dbProvider.Name.ShouldEqual("Npgsql.EntityFrameworkCore.PostgreSQL");
+        }
+
+        [Fact]
+        public void GetDesignTimeServiceProviderPostgreSql()
+        {
+            // Act. 
+            var service = _bookContext.GetDesignTimeService();
+
+            // Assert.
+            service.ShouldNotBeNull();
+            service.ShouldBeType<NpgsqlDesignTimeServices>();
+        }
+
+        [Fact]
+        public void GetIDatabaseModelFactoryPostgreSql()
+        {
+            // Arrange.
+            var dtService = _bookContext.GetDesignTimeService();
+            var serviceProvider = dtService.GetDesignTimeProvider();
+
+            // Act.
+            var factory = serviceProvider.GetService<IDatabaseModelFactory>();
+
+            // Assert.
+            factory.ShouldNotBeNull();
+            factory.ShouldBeType<NpgsqlDatabaseModelFactory>();
+        }
+    }
+}

--- a/TestSupport/DesignTimeServices/DesignProvider.cs
+++ b/TestSupport/DesignTimeServices/DesignProvider.cs
@@ -6,11 +6,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal;
 
 namespace TestSupport.DesignTimeServices
 {
@@ -21,6 +21,7 @@ namespace TestSupport.DesignTimeServices
     {
         private const string SqlServerProviderName = "Microsoft.EntityFrameworkCore.SqlServer";
         private const string SqliteProviderName = "Microsoft.EntityFrameworkCore.Sqlite";
+        private const string NpgsqlProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
 
         /// <summary>
         /// This returns the correct instance of the design time service for the current DbContext
@@ -31,7 +32,7 @@ namespace TestSupport.DesignTimeServices
         {
             var dbProvider = context.GetService<IDatabaseProvider>();
             if (dbProvider == null)
-                throw new InvalidOperationException("Cound not find a database provider service.");
+                throw new InvalidOperationException("Could not find a database provider service.");
 
             var providerName = dbProvider.Name;
 
@@ -39,6 +40,8 @@ namespace TestSupport.DesignTimeServices
                 return new SqlServerDesignTimeServices();
             if (providerName == SqliteProviderName)
                 return new SqliteDesignTimeServices();
+            if (providerName == NpgsqlProviderName)
+                return new NpgsqlDesignTimeServices();
 
             throw new InvalidOperationException("This is not a database provider that we currently support.");
         }
@@ -46,7 +49,7 @@ namespace TestSupport.DesignTimeServices
         /// <summary>
         /// This returns a DesignTimeProvider for the design time service instance that you provided
         /// </summary>
-        /// <param name="designTimeService">This should be an instance of rhe design time service for the database provider</param>
+        /// <param name="designTimeService">This should be an instance of the design time service for the database provider</param>
         /// <returns></returns>
         public static ServiceProvider GetDesignTimeProvider(this IDesignTimeServices designTimeService)
         {

--- a/TestSupport/TestSupport.csproj
+++ b/TestSupport/TestSupport.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.0" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
   </ItemGroup>
@@ -24,6 +25,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />


### PR DESCRIPTION
Hi,

I'm using PostgreSQL, and want to use the EfSchemaCompare feature in the library (I use others as well).

The changes involved in introducing the design-time service for PostgreSQL was minor. But to add tests for that was a bit more complicated. The best and maybe the easiest way to create an EF Core PostgreSQL database context in a test is to use a test container, which boots up an instance of Postgresql, retrieves the connection strings, initializes the Db context, and applies the EF Core migrations on the DB. Note: Docker on the host running the tests is required.

On the other side, managing support for different .NET Frameworks and dependencies are not trivial. I ended up creating a new test project targeting .NET Core 3.1 to be able to use DotNet.TestContainers to run the tests.