### PR TITLE
Update NuGet packages

### DIFF
--- a/DataLayer/DataLayer.csproj
+++ b/DataLayer/DataLayer.csproj
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>		

--- a/DataLayer/DataLayer.csproj
+++ b/DataLayer/DataLayer.csproj
@@ -6,7 +6,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
 		  <PrivateAssets>all</PrivateAssets>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -10,7 +10,6 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
 		<PackageReference Include="RandomNameGeneratorLibrary" Version="1.2.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.3">
 			<PrivateAssets>all</PrivateAssets>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
 		<PackageReference Include="RandomNameGeneratorLibrary" Version="1.2.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/TestSupport/TestSupport.csproj
+++ b/TestSupport/TestSupport.csproj
@@ -6,20 +6,20 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="10.0.0">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="10.0.6">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
 		<PackageReference Include="xunit.assert" Version="2.9.3" />
 		<PackageReference Include="xunit.core" Version="2.9.3" />
 	</ItemGroup>

--- a/TestSupport/TestSupport.csproj
+++ b/TestSupport/TestSupport.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
 		  <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR removes two NuGet packages and updates several others. This change resolves some package vulnerability warnings in applications using `EfCore.TestSupport`.

Specifically, I removed the `Microsoft.Build.Tasks.Core` and `System.Net.Http` packages. You shouldn't need to reference those packages directly in your repository as they're included by default in the SDK/MSBuild. Also, I updated the .NET-related packages from version 10.0.0 to 10.0.6.

Currently, `EfCore.TestSupport` has a transitive dependency on an outdated version of the `System.Security.Cryptography.Xml` package, which is vulnerable and produces build warnings in projects that use it. The changes above remove that outdated dependency.